### PR TITLE
Extract target url from fbrpc:// URLs

### DIFF
--- a/facebook/facebook-api.c
+++ b/facebook/facebook-api.c
@@ -1353,7 +1353,11 @@ fb_api_xma_parse(FbApi *api, const gchar *body, JsonNode *root, GError **error)
     if (g_strcmp0(str, "ExternalUrl") == 0) {
         prms = fb_http_values_new();
         fb_http_values_parse(prms, url, TRUE);
-        text = fb_http_values_dup_str(prms, "u", NULL);
+        if (g_str_has_prefix(url, FB_API_FBRPC_PREFIX)) {
+            text = fb_http_values_dup_str(prms, "target_url", NULL);
+        } else {
+            text = fb_http_values_dup_str(prms, "u", NULL);
+        }
         fb_http_values_free(prms);
     } else {
         text = g_strdup(url);

--- a/facebook/facebook-api.h
+++ b/facebook/facebook-api.h
@@ -68,6 +68,13 @@
 #define FB_API_WHOST  "https://www.facebook.com"
 
 /**
+ * FB_API_FBRPC_PREFIX
+ *
+ * The fbrpc URL prefix used in links shared from the mobile app.
+ */
+#define FB_API_FBRPC_PREFIX "fbrpc://facebook/nativethirdparty"
+
+/**
  * FB_API_KEY:
  *
  * The Facebook API key.


### PR DESCRIPTION
Those URLs seem to be generated when the Android share feature is used.

Fixes #97