### PR TITLE
Remove bash-ism in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,7 +53,7 @@ AC_ARG_ENABLE(
 )
 
 AS_IF(
-    [test "x$WARNINGS" == "xyes"],
+    [test "x$WARNINGS" = "xyes"],
     [CFLAGS="$CFLAGS -Wall -Wextra \
      -Waggregate-return \
      -Wdeclaration-after-statement \


### PR DESCRIPTION
== is incompatible with a non-bash /bin/sh, no reason to use it here.