### PR TITLE
Port away from deprecated g_type_class_add_private() and friends

### DIFF
--- a/facebook/facebook-api.c
+++ b/facebook/facebook-api.c
@@ -100,7 +100,7 @@ fb_api_sticker(FbApi *api, FbId sid, FbApiMessage *msg);
 void
 fb_api_contacts_delta(FbApi *api, const gchar *delta_cursor);
 
-G_DEFINE_TYPE(FbApi, fb_api, G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_PRIVATE(FbApi, fb_api, G_TYPE_OBJECT);
 
 static const gchar *agents[] = {
     FB_API_AGENT,
@@ -240,7 +240,6 @@ fb_api_class_init(FbApiClass *klass)
     gklass->set_property = fb_api_set_property;
     gklass->get_property = fb_api_get_property;
     gklass->dispose = fb_api_dispose;
-    g_type_class_add_private(klass, sizeof (FbApiPrivate));
 
     /**
      * FbApi:cid:
@@ -599,7 +598,7 @@ fb_api_init(FbApi *api)
 {
     FbApiPrivate *priv;
 
-    priv = G_TYPE_INSTANCE_GET_PRIVATE(api, FB_TYPE_API, FbApiPrivate);
+    priv = fb_api_get_instance_private(api);
     api->priv = priv;
 
     priv->http = fb_http_new(FB_API_AGENT);

--- a/facebook/facebook-data.c
+++ b/facebook/facebook-data.c
@@ -37,7 +37,7 @@ static const gchar *fb_props_strs[] = {
     "token"
 };
 
-G_DEFINE_TYPE(FbData, fb_data, G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_PRIVATE(FbData, fb_data, G_TYPE_OBJECT);
 
 static void
 fb_data_dispose(GObject *obj)
@@ -74,7 +74,6 @@ fb_data_class_init(FbDataClass *klass)
     GObjectClass *gklass = G_OBJECT_CLASS(klass);
 
     gklass->dispose = fb_data_dispose;
-    g_type_class_add_private(klass, sizeof (FbDataPrivate));
 }
 
 static void
@@ -82,7 +81,7 @@ fb_data_init(FbData *fata)
 {
     FbDataPrivate *priv;
 
-    priv = G_TYPE_INSTANCE_GET_PRIVATE(fata, FB_TYPE_DATA, FbDataPrivate);
+    priv = fb_data_get_instance_private(fata);
     fata->priv = priv;
 
     priv->api = fb_api_new();

--- a/facebook/facebook-http.c
+++ b/facebook/facebook-http.c
@@ -47,8 +47,8 @@ struct _FbHttpRequestPrivate
     gboolean freed;
 };
 
-G_DEFINE_TYPE(FbHttp, fb_http, G_TYPE_OBJECT);
-G_DEFINE_TYPE(FbHttpRequest, fb_http_request, G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_PRIVATE(FbHttp, fb_http, G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_PRIVATE(FbHttpRequest, fb_http_request, G_TYPE_OBJECT);
 
 static void
 fb_http_dispose(GObject *obj)
@@ -68,7 +68,6 @@ fb_http_class_init(FbHttpClass *klass)
     GObjectClass *gklass = G_OBJECT_CLASS(klass);
 
     gklass->dispose = fb_http_dispose;
-    g_type_class_add_private(klass, sizeof (FbHttpPrivate));
 }
 
 static void
@@ -76,7 +75,7 @@ fb_http_init(FbHttp *http)
 {
     FbHttpPrivate *priv;
 
-    priv = G_TYPE_INSTANCE_GET_PRIVATE(http, FB_TYPE_HTTP, FbHttpPrivate);
+    priv = fb_http_get_instance_private(http);
     http->priv = priv;
 
     priv->cookies = fb_http_values_new();
@@ -116,7 +115,6 @@ fb_http_request_class_init(FbHttpRequestClass *klass)
     GObjectClass *gklass = G_OBJECT_CLASS(klass);
 
     gklass->dispose = fb_http_request_dispose;
-    g_type_class_add_private(klass, sizeof (FbHttpRequestPrivate));
 }
 
 static void
@@ -124,8 +122,7 @@ fb_http_request_init(FbHttpRequest *req)
 {
     FbHttpRequestPrivate *priv;
 
-    priv = G_TYPE_INSTANCE_GET_PRIVATE(req, FB_TYPE_HTTP_REQUEST,
-                                       FbHttpRequestPrivate);
+    priv = fb_http_request_get_instance_private(req);
     req->priv = priv;
 
     priv->headers = fb_http_values_new();

--- a/facebook/facebook-json.c
+++ b/facebook/facebook-json.c
@@ -44,7 +44,7 @@ struct _FbJsonValuesPrivate
     GError *error;
 };
 
-G_DEFINE_TYPE(FbJsonValues, fb_json_values, G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_PRIVATE(FbJsonValues, fb_json_values, G_TYPE_OBJECT);
 
 static void
 fb_json_values_dispose(GObject *obj)
@@ -79,7 +79,6 @@ fb_json_values_class_init(FbJsonValuesClass *klass)
     GObjectClass *gklass = G_OBJECT_CLASS(klass);
 
     gklass->dispose = fb_json_values_dispose;
-    g_type_class_add_private(klass, sizeof (FbJsonValuesPrivate));
 }
 
 static void
@@ -87,8 +86,7 @@ fb_json_values_init(FbJsonValues *values)
 {
     FbJsonValuesPrivate *priv;
 
-    priv = G_TYPE_INSTANCE_GET_PRIVATE(values, FB_TYPE_JSON_VALUES,
-                                       FbJsonValuesPrivate);
+    priv = fb_json_values_get_instance_private(values);
     values->priv = priv;
 
     priv->queue = g_queue_new();

--- a/facebook/facebook-mqtt.c
+++ b/facebook/facebook-mqtt.c
@@ -51,8 +51,8 @@ struct _FbMqttMessagePrivate
     gboolean local;
 };
 
-G_DEFINE_TYPE(FbMqtt, fb_mqtt, G_TYPE_OBJECT);
-G_DEFINE_TYPE(FbMqttMessage, fb_mqtt_message, G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_PRIVATE(FbMqtt, fb_mqtt, G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_PRIVATE(FbMqttMessage, fb_mqtt_message, G_TYPE_OBJECT);
 
 static void
 fb_mqtt_dispose(GObject *obj)
@@ -71,7 +71,6 @@ fb_mqtt_class_init(FbMqttClass *klass)
     GObjectClass *gklass = G_OBJECT_CLASS(klass);
 
     gklass->dispose = fb_mqtt_dispose;
-    g_type_class_add_private(klass, sizeof (FbMqttPrivate));
 
     /**
      * FbMqtt::connect:
@@ -146,7 +145,7 @@ fb_mqtt_init(FbMqtt *mqtt)
 {
     FbMqttPrivate *priv;
 
-    priv = G_TYPE_INSTANCE_GET_PRIVATE(mqtt, FB_TYPE_MQTT, FbMqttPrivate);
+    priv = fb_mqtt_get_instance_private(mqtt);
     mqtt->priv = priv;
 
     priv->rbuf = g_byte_array_new();
@@ -169,7 +168,6 @@ fb_mqtt_message_class_init(FbMqttMessageClass *klass)
     GObjectClass *gklass = G_OBJECT_CLASS(klass);
 
     gklass->dispose = fb_mqtt_message_dispose;
-    g_type_class_add_private(klass, sizeof (FbMqttMessagePrivate));
 }
 
 static void
@@ -177,8 +175,7 @@ fb_mqtt_message_init(FbMqttMessage *msg)
 {
     FbMqttMessagePrivate *priv;
 
-    priv = G_TYPE_INSTANCE_GET_PRIVATE(msg, FB_TYPE_MQTT_MESSAGE,
-                                       FbMqttMessagePrivate);
+    priv = fb_mqtt_message_get_instance_private(msg);
     msg->priv = priv;
 }
 

--- a/facebook/facebook-thrift.c
+++ b/facebook/facebook-thrift.c
@@ -28,7 +28,7 @@ struct _FbThriftPrivate
     guint lastbool;
 };
 
-G_DEFINE_TYPE(FbThrift, fb_thrift, G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_PRIVATE(FbThrift, fb_thrift, G_TYPE_OBJECT);
 
 static void
 fb_thrift_dispose(GObject *obj)
@@ -46,7 +46,6 @@ fb_thrift_class_init(FbThriftClass *klass)
     GObjectClass *gklass = G_OBJECT_CLASS(klass);
 
     gklass->dispose = fb_thrift_dispose;
-    g_type_class_add_private(klass, sizeof (FbThriftPrivate));
 }
 
 static void
@@ -54,8 +53,7 @@ fb_thrift_init(FbThrift *thft)
 {
     FbThriftPrivate *priv;
 
-    priv = G_TYPE_INSTANCE_GET_PRIVATE(thft, FB_TYPE_THRIFT,
-                                       FbThriftPrivate);
+    priv = fb_thrift_get_instance_private(thft);
     thft->priv = priv;
 }
 


### PR DESCRIPTION
g_type_class_add_private() and G_TYPE_INSTANCE_GET_PRIVATE() were
deprecated in GLib 2.58.  Instead, use
G_DEFINE_[ABSTRACT_]TYPE_WITH_PRIVATE(), and
G_ADD_PRIVATE[_DYNAMIC](), and the implictly-defined
foo_get_instance_private() functions, all of which are available in
the GLib versions we depend on.

https://developer.gnome.org/gobject/stable/gobject-Type-Information.html#G-TYPE-INSTANCE-GET-PRIVATE:CAPS