### PR TITLE
facebook-api: Fix id assertion in fb_api_cb_publish_mst()

### DIFF
--- a/facebook/facebook-api.c
+++ b/facebook/facebook-api.c
@@ -1544,7 +1544,8 @@ fb_api_cb_publish_mst(FbThrift *thft, GError **error)
 
         FB_API_TCHK(fb_thrift_read_field(thft, &type, &id, 0));
         FB_API_TCHK(type == FB_THRIFT_TYPE_STRING);
-        FB_API_TCHK(id == 2);
+        fb_util_debug_info("fb_api_cb_publish_mst() id: %d", id);
+        FB_API_TCHK(id == 1 || id == 2);
         FB_API_TCHK(fb_thrift_read_str(thft, NULL));
         FB_API_TCHK(fb_thrift_read_stop(thft));
     }


### PR DESCRIPTION
Sometimes `id` comes back as 1, but whether it's 1 or 2,
`fb_thrift_read_str()` seems to do the right thing. This prevents
crashes of this nature:

```
facebook - Error: Failed to read thrift: facebook-api.c:1548 fb_api_cb_publish_mst: assertion 'id == 2'
```

Note this happens when connected to a workplace account, in case others
haven't seen it.