### PR TITLE
configure: drop the unnecessary AC_PROG_CC macro check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,7 +32,6 @@ AM_PROG_CC_C_O
 LT_INIT([disable-static])
 
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
-m4_ifdef([AC_PROG_CC],  [AC_PROG_CC])
 
 # Define PKG_CHECK_VAR() for pkg-config < 0.28
 m4_define_default(


### PR DESCRIPTION
This check after commit d8e6c72 breaks build with automake < 1.14
due to a bug, where the AM_PROG_CC_C_O macro overwrites AC_PROG_CC,
triggering an error:

```
$ automake --version | head -n1
automake (GNU automake) 1.13.4
$ ./autogen.sh
autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -Im4
configure.ac:35: error: AC_PROG_CC cannot be called after AM_PROG_CC_C_O
configure.ac:35: the top level
autom4te: /usr/bin/m4 failed with exit status: 1
aclocal: error: echo failed with exit status: 1
autoreconf: aclocal failed with exit status: 1
```

---

If I'm not missing anything this should be safe, since the `AC_PROG_CC` and `AM_PROG_CC_C_O` macros do the compiler sanity checks anyway.