### PR TITLE
use FB_ORCA_AGENT from purple-facebook

### DIFF
--- a/facebook/facebook-api.h
+++ b/facebook/facebook-api.h
@@ -117,7 +117,7 @@
  *
  */
 
-#define FB_ORCA_AGENT "[FBAN/Orca-Android;FBAV/537.0.0.31.101;FBBV/14477681]"
+#define FB_ORCA_AGENT "[FBAN/Orca-Android;FBAV/537.0.0.31.101;FBPN/com.facebook.orca;FBLC/en_US;FBBV/52182662]"
 
 /**
  * FB_API_AGENT:


### PR DESCRIPTION
Fixes facebook authentication error - `User must verify their account on www.facebook.com (405)`
I don't understand why it fixes it really, but had the idea because i could login without a problem with pidgin.