### PR TITLE
facebook/Makefile.am: add generated files to BUILT_SOURCES

### DIFF
--- a/facebook/Makefile.am
+++ b/facebook/Makefile.am
@@ -38,6 +38,10 @@ facebook_la_LDFLAGS += -module -avoid-version
 EXTRA_DIST = \
 	marshaller.list
 
+BUILT_SOURCES = \
+	facebook-marshal.c \
+	facebook-marshal.h
+
 CLEANFILES = \
 	facebook-marshal.c \
 	facebook-marshal.h


### PR DESCRIPTION
Without the change there is no giarantee that facebook-marshal.h gets built before it's dependencies. On `make-4.4` `--shuffle` is able to catch missing dependency as:

    $ make --shuffle
      CC       facebook_la-facebook-mqtt.lo
    facebook-mqtt.c:23:10: fatal error: facebook-marshal.h: No such file or directory
       23 | #include "facebook-marshal.h"
          |          ^~~~~~~~~~~~~~~~~~~~

Automake's BUILT_SOURCES builds all sources before first object file. The change pulls it there.

Before the change 1-2 builds triggered `make --shuffle` failure. After the change 20 sequential rebuilds succeeded without failures.